### PR TITLE
Remove misleading copy about HTTPS

### DIFF
--- a/_includes/components/banner.html
+++ b/_includes/components/banner.html
@@ -33,7 +33,7 @@
             <p>
               <strong>The site is secure.</strong>
               <br>
-              The <strong>https://</strong> ensures that you are connecting to the official website and that any information you provide is encrypted and transmitted securely.
+              The <strong>https://</strong> ensures that any information you provide is encrypted and transmitted securely.
             </p>
           </div>
         </div>


### PR DESCRIPTION
First of all, I want to say thank you for all the work that you do!

I hope this doesn't come off as overly pedantic, but I don't think people should be told that HTTPS ensures they're on an official website. HTTPS can't guarantee the officialness of a website since anyone can get an SSL certificate without any identity verification. It's commonly used by phishers to make their unofficial sites look more legitimate.

For example, `https://WestemUnion.com` is not the official Western Union website, but it does have a valid SSL certificate. (they're currently redirecting to HTTP for some reason, but the SSL _is_ set up).

I'm open to discussing this if you have any questions, thanks for your consideration!