### PR TITLE
Fix sidenav highlighting by removing .current-parent

### DIFF
--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -8,7 +8,7 @@
     {% endif %}
   <li>
     <a href="{{ _href | relative_url }}"{% if _current %}
-      class="usa-current"{% endif %}{% if page.url contains link.href or page.permalink contains link.href %} class="current-parent"{% endif %}>
+      class="usa-current"{% endif %}>
       {{ link.text }}
     </a>
     {% if link.subnav %}

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -147,12 +147,6 @@ main {
   }
 }
 
-.usa-nav-link.current-parent span {
-  // border-bottom: 0.7rem solid $color-primary;
-  color: $color-primary;
-  padding-bottom: 1rem;
-}
-
 .usa-nav-link:hover span,
 .usa-nav-primary a.usa-current span {
   @include media($nav-width) {
@@ -313,9 +307,6 @@ main {
     }
   }
 
-  .current-parent {
-    border-left: 0.4rem solid $color-primary;
-  }
 }
 
 .usa-sidenav-list + .usa-sidenav-contents-heading {


### PR DESCRIPTION
Fixes #93 by removing the `.current-parent` class entirely, which isn't required for the website at all.

Now, the same page renders properly:

![image](https://user-images.githubusercontent.com/1689183/110409317-105c6c00-8055-11eb-8906-34508b697afb.png)
