### PR TITLE
Remove usa-overlay

### DIFF
--- a/_includes/components/header.html
+++ b/_includes/components/header.html
@@ -112,5 +112,4 @@
   {% endif %}
 
 </header>
-<div class="usa-overlay"></div>
 {% endif %}

--- a/_sass/lib/uswds/components/_header.scss
+++ b/_sass/lib/uswds/components/_header.scss
@@ -101,20 +101,6 @@ $z-index-nav:     9000;
   }
 }
 
-.usa-overlay {
-  @include position(fixed, 0);
-  background: $color-black;
-  opacity: 0;
-  transition: all 0.2s ease-in-out;
-  visibility: hidden;
-  z-index: $z-index-overlay;
-
-  &.is-visible {
-    opacity: 0.1;
-    visibility: visible;
-  }
-}
-
 // Basic header ----------- //
 
 .usa-header-basic {


### PR DESCRIPTION
It looks like this component isn't needed at all, as removing it
doesn't change anything with the site (except for fixing #63).

Fixes #63


