### PR TITLE
Update location of .gov data

### DIFF
--- a/pages/data.md
+++ b/pages/data.md
@@ -12,14 +12,14 @@ subnav:
 
 ### All .gov domains
 
-The official public list of `.gov` domains is updated about every two weeks:
+The official public list of `.gov` domains is updated regularly:
 
-* [List of .gov domains](https://github.com/GSA/data/raw/master/dotgov-domains/current-full.csv) - includes all federal, state, interstate, local, and tribal `.gov` and `.fed.us` domains.
+* [List of .gov domains](https://raw.githubusercontent.com/cisagov/dotgov-data/main/current-full.csv) - includes all federal, state, interstate, local, and tribal `.gov` and `.fed.us` domains.
 
 ### Federal .gov domains
 
-* [List of federal .gov domains](https://github.com/GSA/data/raw/master/dotgov-domains/current-federal.csv) - includes federal `.gov` and `.fed.us` domains only.
+* [List of federal .gov domains](https://raw.githubusercontent.com/cisagov/dotgov-data/main/current-federal.csv) - includes federal `.gov` and `.fed.us` domains only.
 
 ### Share your feedback
 
-If you have questions about the data or suggestions for improving it, [open an issue in our GitHub repository](https://github.com/gsa/data/issues).
+If you have questions about the data or suggestions for improving it, [open an issue in our GitHub repository](https://github.com/cisagov/dotgov-data/issues).


### PR DESCRIPTION
This very small change switches the location of .gov domain data from [GSA/data](https://github.com/GSA/data) to [cisagov/dotgov-data](https://github.com/cisagov/dotgov-data).