### PR TITLE
Two small fixes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,8 +22,6 @@ exclude:
 - README.md
 - vendor
 
-styles:
-  - /assets/css/main.css
 
 defaults:
   - scope:
@@ -31,6 +29,7 @@ defaults:
       type: "pages"
     values:
       layout: "default"
+
 
 collections:
   pages:

--- a/pages/registration/requirements.md
+++ b/pages/registration/requirements.md
@@ -119,7 +119,7 @@ The public may report suspected security issues or other serious violations to <
 ## Specific requirements
 ### Federal domains
 
-All [general requirements] apply. Use the authorization letter template.
+All [general requirements](#general-requirements) apply. Use the authorization letter template.
 
 #### Legislative branch authorizing authority
 Domain requests from the Senate and House of Representatives, including their offices and organizations, must come from the Senate Sergeant at Arms, or the House Chief Administrative Officer.


### PR DESCRIPTION
This has two fixes:

* I noticed that `main.css` was being pulled in twice:
<img src="https://user-images.githubusercontent.com/4592/116349060-0a0c8580-a7a4-11eb-81aa-9c38e7788cdd.png" width="400">

I'm honestly not sure where the second source is. This is clearly relying on behavior from [`uswds-jekyll`](https://github.com/18F/uswds-jekyll/blob/master/_includes/styles.html), whose behavior seen in that link shows that it iterates through styles set in a lot of places. The one I removed is the only reference in the project to `styles` I could find, but clearly there's another one (or a default) somewhere. I'm going to guess that `uswds-jekyll` defaults to pulling in a `main.css` itself, making the explicit use in `_config.yml`  unnecessary.

* There's some exposed Markdown on the domain registration requirements, it's missing a URL destination of an anchor link, which I added. It's [visible here](https://home.dotgov.gov/registration/requirements/#specific-requirements):

<img src="https://user-images.githubusercontent.com/4592/116349344-a33b9c00-a7a4-11eb-8bf5-06fa464c8fcd.png" width=400>



