### PR TITLE
Add RFI link, update about and FAQ pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,8 +2,8 @@
 theme: uswds-jekyll
 
 # OpenGraph / Twitter metadata
-title: DotGov
-description: .gov is the top-level domain for U.S.-based government organizations.
+title: .gov
+description: The top-level domain for U.S.-based government organizations
 
 # GA and GitHub data
 google_analytics_ua: ua-33523145-2

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,7 +1,7 @@
 primary:
   - text: Registration
     href: /registration/
-  - text: About us
+  - text: About
     href: /about/
   - text: Updates
     href: /updates/

--- a/pages/about/about.md
+++ b/pages/about/about.md
@@ -1,19 +1,41 @@
 ---
-title: About us
+title: About
 layout: docs
 permalink: /about/
-intro: .gov puts U.S. governments on the internet.
+intro: We put U.S. governments on the internet.
 subnav:
-  - text: About us
-    href: '#about-us'
+  - text: Why use .gov?
+    href: '#why-use-gov'
+  - text: What does .gov do?
+    href: '#what-does-gov-do'
 
 ---
-Bona fide government services should be **easy to identify on the internet.** The DotGov Program, part of the [Cybersecurity and Infrastructure Security Agency](https://www.cisa.gov), operates the .gov top-level domain (TLD) and makes it available to U.S.-based government organizations, from federal agencies to local municipalities. Using a .gov domain shows you’re official.
 
-We make it easy to register a .gov domain name and ensure that the name resolves in the global domain name system (DNS). DNS maps easy-to-remember names on top of hard-to-recall numbers, allowing you to use `cisa.gov` instead of something like `104.106.178.124`.
+### Why use .gov?
 
-.gov domains are intertwined with access to government services, and that makes .gov critical infrastructure for governments, citizens, and international internet users. We work to make .gov a **trusted, secure space**: we publish our [policies]({{ site.baseurl }}/registration/requirements/), recommend [security best practices]({{ site.baseurl }}/help/security-best-practices/), and make .gov domain [data]({{ site.baseurl }}/data/) publicly available.
+.gov is a 'top-level domain', or TLD, similar to _.com_, _.org_, or _.us_. Individuals and enterprises use a TLD to register a domain name (often simply called a _domain_) for use in their online services, like a website or email.
 
-We put U.S. governments on the internet, but there are some things we *don’t* do. DotGov doesn’t offer authoritative DNS services, host .gov websites or email, or monitor all .gov network traffic.
+In many well-known TLDs, anyone can register a domain for a fee, and as long as they pay there aren't many questions asked about whether the name they chose corresponds to their real-life name or services. While this can be a useful property in enabling creative communication, it can also make it difficult to know whether the people behind a name are who they _really_ claim to be.
 
-If you're from the government, **we're here to help**. Contact us at <registrar@dotgov.gov>.
+**It should be easy to identify governments on the internet**, and using a .gov domain shows you’re official. The public shouldn't have to guess whether the site they're on or the email that hits their inbox is genuine.
+
+[CISA](https://www.cisa.gov), the Cybersecurity and Infrastructure Security Agency, [sponsors the .gov TLD](https://www.iana.org/domains/root/db/gov.html) and makes it available _solely_ to U.S.-based government organizations and publicly controlled entities. For those that qualify for a .gov domain, it's available without a fee.
+
+_If you're from the government, we're here to help_. Check out our [registration page]({{ site.baseurl }}/registration/) to begin.
+
+---
+
+### What does .gov do?
+
+We make it easy to register a .gov domain name and ensure that the name resolves in the global domain name system ([DNS]( {{  site.baseurl }}/help/#dns)). DNS maps easy-to-remember names on top of hard-to-recall numbers, allowing you to use `cisa.gov` instead of something like `104.106.178.124`.
+
+.gov domains are intertwined with access to public services. That makes the .gov TLD _critical infrastructure_ for governments, citizens, and international internet users. We work to **make .gov a trusted, secure space** by:  
+
+* administering our [domain requirements]({{ site.baseurl }}/registration/requirements/),
+* publishing the [complete list of .gov domains]({{ site.baseurl }}/data/),
+* recommending [security best practices]({{ site.baseurl }}/help/security-best-practices/), and
+* implementing [key initiatives]( {{site.baseurl }}/2020/6/21/an-intent-to-preload/) to protect the entire namespace.
+
+We put U.S. governments on the internet, but there are some things we *don’t* do. We don't offer authoritative DNS services, host .gov websites or email, or monitor all .gov network traffic.
+
+Have a question? [Contact us]( {{site.baseurl }}/help/#contact-us).

--- a/pages/data.md
+++ b/pages/data.md
@@ -2,24 +2,25 @@
 title: Data
 layout: docs
 permalink: /data/
+intro: The complete list of .gov domains is updated regularly.
 
 subnav:
-  - text: Download our data
+  - text: All .gov domains
     href: '#all-gov-domains'
-  - text: Share your feedback
-    href: '#share-your-feedback'
+  - text: Federal .gov domains
+    href: '#federal-gov-domains'
 ---
 
-### All .gov domains
+#### All .gov domains
 
-The official public list of `.gov` domains is updated regularly:
+Includes all registered domains from every [domain type]({{ site.baseurl }}/help/#whats-an-authorizing-authority-and-who-is-ours): _federal, tribal, state/territory, interstate, independent intrastate,_ and _city/county_.
 
-* [List of .gov domains](https://raw.githubusercontent.com/cisagov/dotgov-data/main/current-full.csv) - includes all federal, state, interstate, local, and tribal `.gov` and `.fed.us` domains.
+* **[All .gov domains](https://raw.githubusercontent.com/cisagov/dotgov-data/main/current-full.csv)** (.csv)
 
-### Federal .gov domains
+#### Federal .gov domains
 
-* [List of federal .gov domains](https://raw.githubusercontent.com/cisagov/dotgov-data/main/current-federal.csv) - includes federal `.gov` and `.fed.us` domains only.
+Includes all domain names registered to federal agencies: _legislative, executive,_ and _judicial_. (This is a subset of the file above.)
 
-### Share your feedback
+* **[Federal .gov domains](https://raw.githubusercontent.com/cisagov/dotgov-data/main/current-federal.csv)** (.csv)
 
-If you have questions about the data or suggestions for improving it, [open an issue in our GitHub repository](https://github.com/cisagov/dotgov-data/issues).
+>_If you have questions about the data or suggestions for improving it, [open an issue in our GitHub repository](https://github.com/cisagov/dotgov-data/issues)._

--- a/pages/forms/city-county.md
+++ b/pages/forms/city-county.md
@@ -6,7 +6,7 @@ permalink: /registration/authorization-templates/city-county/
 sidenav: registration
 ---
 
-[City Government Letterhead]
+[City government letterhead]
 
 [Date]
 
@@ -17,7 +17,7 @@ Reston, Virginia 20190
 
 To the .gov Program:
 
-As [[authorizing authority]({{ site.baseurl }}/registration/requirements/#city-and-county-domains)] for [City/County], I request that responsibility for the domain name [\_\_\_\_\_\_\_\_\_\_\_.gov] be delegated to my municipality.
+As [authorizing authority]({{ site.baseurl }}/registration/requirements/#city-and-county-domains) for [City/County], I request that responsibility for the domain name [\_\_\_\_\_\_\_\_\_\_\_.gov] be delegated to my municipality.
 
 [*Briefly describe the mission or initiative that drives the domain name request, explaining what the domain name will be used for.*]
 

--- a/pages/forms/federal.md
+++ b/pages/forms/federal.md
@@ -17,7 +17,7 @@ Reston, Virginia 20190
 
 To the .gov Program:
 
-As [[authorizing authority]({{ site.baseurl }}/registration/requirements/#federal-domains)] for [Agency Name], I request that responsibility for the domain name [\_\_\_\_\_\_\_\_\_\_\_.gov\] be delegated to my organization.
+As [authorizing authority]({{ site.baseurl }}/registration/requirements/#federal-domains) for [Agency Name], I request that responsibility for the domain name [\_\_\_\_\_\_\_\_\_\_\_.gov\] be delegated to my organization.
 
 [*Briefly describe your agency's mission or initiative that drives the domain name request, explaining what the domain name will be used for.*]
 

--- a/pages/forms/independent-intrastate.md
+++ b/pages/forms/independent-intrastate.md
@@ -17,7 +17,7 @@ Reston, Virginia 20190
 
 To the .gov Program:
 
-As [[authorizing authority]({{ site.baseurl }}/registration/requirements/#independent-intrastate-domains)] for [Agency Name], I request that responsibility for the domain name [\_\_\_\_\_\_\_\_\_\_\_.gov] be delegated to [Organization].
+As [authorizing authority]({{ site.baseurl }}/registration/requirements/#independent-intrastate-domains) for [Agency Name], I request that responsibility for the domain name [\_\_\_\_\_\_\_\_\_\_\_.gov] be delegated to [Organization].
 
 [*Briefly describe your organization's mission or initiative that drives the domain name request, explaining what the domain name will be used for. Describe how your organization is a bona fide government organization that is independent of your state's government. Include links to, or add as an appendix, authorizing legislation, applicable bylaws or charter, or other documentation to support your claims.*]
 

--- a/pages/forms/interstate.md
+++ b/pages/forms/interstate.md
@@ -17,7 +17,7 @@ Reston, Virginia 20190
 
 To the .gov Program:
 
-As [[authorizing authority]({{ site.baseurl }}/registration/requirements/#interstate-domains)] for [Agency Name], I request that responsibility for the domain name [\_\_\_\_\_\_\_\_\_\_\_.gov] be delegated to [Organization].
+As [authorizing authority]({{ site.baseurl }}/registration/requirements/#interstate-domains) for [Agency Name], I request that responsibility for the domain name [\_\_\_\_\_\_\_\_\_\_\_.gov] be delegated to [Organization].
 
 [*Briefly describe your organization's mission or initiative that drives the domain name request, explaining what the domain name will be used for. List the states your organization is associated with and describe the nature of the relationship between them and your organization. Include links to, or add as an appendix, authorizing legislation, applicable bylaws or charter, or other documentation that demonstrates your being a bona fide interstate governmental organization.*]
 

--- a/pages/forms/native-sovereign-nation.md
+++ b/pages/forms/native-sovereign-nation.md
@@ -17,7 +17,7 @@ Reston, Virginia 20190
 
 To the .gov Program:
 
-As [[authorizing authority]({{ site.baseurl }}/registration/requirements/#native-sovereign-nation-tribal-domains)] for [Tribe recognized by the Federal or a State government], I request that responsibility for the domain name [\_\_\_\_\_\_\_\_\_\_\_.gov] be delegated to my tribe.
+As [authorizing authority]({{ site.baseurl }}/registration/requirements/#native-sovereign-nation-tribal-domains) for [Tribe recognized by the Federal or a State government], I request that responsibility for the domain name [\_\_\_\_\_\_\_\_\_\_\_.gov] be delegated to my tribe.
 
 [*Briefly describe the mission or initiative that drives the domain name request, explaining what the domain name will be used for. Include links to, or add as an appendix, authorizing Tribal resolution, legislation, applicable bylaws or charter, or other documentation that demonstrates your tribe has been recognized by the Federal or a State government.*]
 

--- a/pages/forms/state-territory.md
+++ b/pages/forms/state-territory.md
@@ -17,7 +17,7 @@ Reston, Virginia 20190
 
 To the .gov Program:
 
-As [[authorizing authority]({{ site.baseurl }}/registration/requirements/#state-and-us-territory-domains)] for [Agency Name], I request that responsibility for the domain name [\_\_\_\_\_\_\_\_\_\_\_.gov] be delegated to [Organization].
+As [authorizing authority]({{ site.baseurl }}/registration/requirements/#state-and-us-territory-domains) for [Agency Name], I request that responsibility for the domain name [\_\_\_\_\_\_\_\_\_\_\_.gov] be delegated to [Organization].
 
 [*Briefly describe your organization's mission or initiative that drives the domain name request, explaining what the domain name will be used for.*]
 

--- a/pages/forms/transfers.md
+++ b/pages/forms/transfers.md
@@ -17,7 +17,7 @@ Reston, Virginia 20190
 
 To the .gov Program:
 
-As [[authorizing authority]({{ site.baseurl }}/registration/requirements/#federal-domains)] for [Agency Name], I request that responsibility for the domain name [\_\_\_\_\_\_\_\_\_\_\_.gov\] be transferred [to \_\_\_\_\_\_\_\_\_\_\_ /from my organization].
+As [authorizing authority]({{ site.baseurl }}/registration/requirements/#federal-domains) for [Agency Name], I request that responsibility for the domain name [\_\_\_\_\_\_\_\_\_\_\_.gov\] be transferred [to \_\_\_\_\_\_\_\_\_\_\_ /from my organization].
 
 [*Briefly state why this domain is being transferred to/from your agency.*]
 

--- a/pages/help/help.md
+++ b/pages/help/help.md
@@ -38,6 +38,7 @@ We also recommend you review our [domain security best practices]({{ site.baseur
 
 * [Who can obtain a .gov domain and what are the requirements?](#who-can-obtain-a-gov-domain-and-what-are-the-requirements)
 * [What's an "authorizing authority", and who is ours?](#whats-an-authorizing-authority-and-who-is-ours)
+* [We're an elections office. Who is our authorizing authority?](#were-an-elections-office-who-is-our-authorizing-authority)
 * [What contact information do we need to keep updated?](#what-contact-information-do-we-need-to-keep-updated)
 * [How do I request an exception to the naming requirements?](#how-do-i-request-an-exception-to-the-naming-requirements)
 * [My authorizing authority won’t sign an authorization letter. What do I do now?](#my-authorizing-authority-wont-sign-an-authorization-letter-what-do-i-do-now)
@@ -112,7 +113,13 @@ Administrative and technical contacts have accounts to the .gov registrar and ca
 
 A **[security contact]({{ site.baseurl }}/help/security-best-practices/#add-a-security-contact)** is a recommended practice. It should be added to allow the public to report observed or suspected security issues at your domain. *Security contact details are made public.* We recommend using an alias, like `security@<domain.gov>`.
 
+> **Note**: The security contact role *does not* have an account to the .gov registrar.
+
 At present, we don't allow a single person to serve as more than one contact – even for the billing account - meaning that three distinct contacts are required. (This does *not* apply to security contact.)
+
+#### We're an elections office. Who is our authorizing authority?
+
+In general, elections offices maintain legal or practical autonomy from a municipality. Elections offices should follow the requirements for [independent intrastate]({{ site.baseurl }}/registration/requirements/#independent-intrastate-domains) domains. The authorization authority is the highest election official. For state-level election offices, the authorizing authority is typically the state's chief election official. For local-level election offices, the highest level election official is typically the elected or appointed official that runs the office.
 
 #### How do I request an exception to the naming requirements?
 

--- a/pages/home.md
+++ b/pages/home.md
@@ -23,6 +23,8 @@ hero:
 
 <div class="usa-width-two-thirds">
 
+**June 30th, 2021**: We [released an RFI](https://sam.gov/opp/231e3374f3fe449ebd31d51e1454029e/view) to gather feedback on our objectives for .gov's next phase. We’d like to hear from interested service providers, U.S.-based government organizations, and others willing to share their unique insights.
+
 **April 27th, 2021**: .gov domains are [available at no cost]({{ site.baseurl }}/2021/4/27/a-new-day-for-gov/) to qualifying U.S.-based government organizations. We’ve also updated the [requirements]({{ site.baseurl }}/registration/requirements/) to obtain and maintain a .gov domain.
 
 **March 8, 2021:** The .gov top-level domain is moving to the Cybersecurity and Infrastructure Security Agency. See our [announcement]({{ site.baseurl }}/2021/3/8/moving-to-cisa/).

--- a/pages/registration/registration.md
+++ b/pages/registration/registration.md
@@ -1,8 +1,8 @@
 ---
-title: Want a .gov? Start here.
+title: Registration
 layout: docs
 permalink: /registration/
-intro: Welcome. We're here to make it easy to identify your government organization on the internet.
+intro: Want a .gov? Start here.
 sidenav: registration
 subnav:
   - text: New to .gov
@@ -13,7 +13,7 @@ subnav:
     href: '#need-help'
 ---
 
-| **[I'm new to .gov](#new-to-gov)**| **[I have a .gov and want another](#get-another-gov-domain)** |
+| _[I'm new to .gov](#new-to-gov)_| _[I want another .gov domain](#get-another-gov-domain)_ |
 
 ## New to .gov
 *This section describes the process for those without any .gov domain names.*

--- a/pages/updates/updates.md
+++ b/pages/updates/updates.md
@@ -16,6 +16,9 @@ subnav:
     href: '#2017'
 ---
 ### 2021
+
+* *June 30:* **[A request for information](https://sam.gov/opp/231e3374f3fe449ebd31d51e1454029e/view)**. We released an RFI to gather feedback on our objectives for .gov's next phase. 
+
 * *April 27:* **[A new day for .gov]({{ site.baseurl }}/2021/4/27/a-new-day-for-gov/)**. Domains are available to qualifying U.S.-based government organizations *at no cost*, and the registration requirements have been updated.
 
 * *March 8:* **[.gov is moving to CISA]({{ site.baseurl }}/2021/3/8/moving-to-cisa/)**. The .gov TLD is moving to the Cybersecurity and Infrastructure Security Agency.


### PR DESCRIPTION
This PR adds a link to the .gov RFI, works to make a short, clear case for governments to use gov, and adds an FAQ about election orgs. The language on the data page was also updated.