### PR TITLE
Add election "about" page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -10,7 +10,6 @@ primary:
   - text: Help
     href: /help/
 
-
 registration:
   - text: Registration
     href: /registration/
@@ -18,6 +17,12 @@ registration:
     href: /registration/requirements/
   - text: Authorization letter templates
     href: /registration/authorization-templates/
+
+about:
+    - text: About
+      href: /about/
+    - text: About, for elections
+      href: /about/elections/
 
 management:
     - text: Domain management

--- a/pages/about/about.md
+++ b/pages/about/about.md
@@ -3,6 +3,7 @@ title: About
 layout: docs
 permalink: /about/
 intro: We put U.S. governments on the internet.
+sidenav: about
 subnav:
   - text: Why use .gov?
     href: '#why-use-gov'
@@ -15,7 +16,7 @@ subnav:
 
 .gov is a 'top-level domain', or TLD, similar to _.com_, _.org_, or _.us_. Individuals and enterprises use a TLD to register a domain name (often simply called a _domain_) for use in their online services, like a website or email.
 
-In many well-known TLDs, anyone can register a domain for a fee, and as long as they pay there aren't many questions asked about whether the name they chose corresponds to their real-life name or services. While this can be a useful property in enabling creative communication, it can also make it difficult to know whether the people behind a name are who they _really_ claim to be.
+In many well-known TLDs, anyone can register a domain for a fee, and as long as they pay there aren't many questions asked about whether the name they chose corresponds to their real-life name or services. While this can be a useful property for creative communication, it can also make it difficult to know whether the people behind a name are _really_ who they claim to be.
 
 **It should be easy to identify governments on the internet**, and using a .gov domain shows you’re official. The public shouldn't have to guess whether the site they're on or the email that hits their inbox is genuine.
 

--- a/pages/about/elections.md
+++ b/pages/about/elections.md
@@ -5,10 +5,8 @@ permalink: /about/elections/
 intro: For the election community
 sidenav: about
 subnav:
-  - text: Why use .gov?
-    href: '#why-use-gov'
-  - text: What does .gov do?
-    href: '#what-does-gov-do'
+  - text: Frequently asked questions
+    href: '#frequently-asked-questions'
 
 ---
 State and local election offices are increasingly tasked with [countering false or misleading information](https://www.cisa.gov/mdm) _about_ an election on top of _administering_ an election. One concrete response you can take is to make it **easy to identify official election information on the internet**, a task made simple by .gov.  
@@ -54,7 +52,7 @@ The U.S. Election Assistance Commission (EAC) has acknowledged that Help America
 The DOTGOV Act made “[migrating any online service](https://uscode.house.gov/view.xhtml?req=%22migrating+any+online+service%22&f=treesort&fq=true&num=0&hl=true&edition=prelim&granuleId=USC-prelim-title6-section609)” to .gov an allowable expense under the Homeland Security Grant Program. FEMA manages the grant program, and potential grantees may include transition costs in their ‘investment justification’ submission. For more information, see [FEMA's preparedness grants manual](https://www.fema.gov/sites/default/files/documents/FEMA_2021-Preparedness-Grants-Manual_02-19-2021.pdf#page=50) (PDF, page 50).
 
 <h5>_State and local collaboration_</h5>
-Election infrastructure often relies on municipal infrastructure, so you may consider collaborating locally to secure resources to transition to .gov. (U.S.-based government organizations qualify for a .gov domain!)
+Election infrastructure often relies on municipal infrastructure, so you may consider collaborating locally to secure resources to transition to .gov. (Non-election U.S.-based government organizations [qualify]({{ site.baseurl }}/about) for a .gov domain.)
 
 #### What other resources are available to elections offices?
 

--- a/pages/about/elections.md
+++ b/pages/about/elections.md
@@ -48,7 +48,7 @@ Though CISA has [removed]({{ site.baseurl }}/2021/4/27/a-new-day-for-gov/) regis
 The U.S. Election Assistance Commission (EAC) has acknowledged that Help America Vote Act (HAVA) funds can be used for the process of transitioning to a .gov domain. Election officials are advised to consult with the EAC before making any purchase to ensure it is an appropriate expenditure of funds under the rules governing the grants. For more information, [contact the EAC](https://www.eac.gov/contactuseac).
 
 <h5>_Homeland Security Grant Program_</h5>
-In the DOTGOV Act, “migrating any online service” to .gov became an allowable expense under the Homeland Security Grant Program. FEMA manages the grant program,  and potential grantees can include transitioning in their ‘investment justification’ submission.” For more information, see [fema.gov](https://www.fema.gov/sites/default/files/documents/FEMA_2021-Preparedness-Grants-Manual_02-19-2021.pdf#page=50).
+In the DOTGOV Act, “migrating any online service” to .gov became an allowable expense under the Homeland Security Grant Program. FEMA manages the grant program,  and potential grantees can include transitioning in their ‘investment justification’ submission. For more information, see [fema.gov](https://www.fema.gov/sites/default/files/documents/FEMA_2021-Preparedness-Grants-Manual_02-19-2021.pdf#page=50).
 
 <h5>_State and local collaboration_</h5>
 Election infrastructure often relies on municipality infrastructure, so you may consider collaborating locally to ensure resources are available to transition to .gov. (Non-election government organizations also qualify for a .gov domain!)

--- a/pages/about/elections.md
+++ b/pages/about/elections.md
@@ -13,12 +13,12 @@ subnav:
 ---
 State and local election offices are increasingly tasked with [countering false or misleading information](https://www.cisa.gov/mdm) _about_ an election on top of _administering_ an election. One concrete response you can take is to make it **easy to identify official election information on the internet**, a task made simple by .gov.  
 
-Using a .gov domain for your online presence (like your website and email) helps the public quickly identify you as a trusted government source. That confidence is merited because only U.S.-based government organizations can register a .gov domain. This is different than other well-known ‘top-level domains’ like _.com_, _.org_, or _.us_) where anyone in the world can register for a small fee. Malicious actors know this, and they’ve [sought to impersonate](https://www.ic3.gov/Media/Y2020/PSA201002) election organizations. A .gov domain name is available **at no cost**.
+Using a .gov domain for your online services (like your website or email) helps the public quickly identify you as a trusted government source. That confidence is merited because only U.S.-based government organizations can register a .gov domain, available **at no cost**. This is different than other well-known ‘top-level domains’ like _.com_, _.org_, or _.us_) where anyone in the world can register for a fee. Malicious actors know this, and they’ve [sought to impersonate](https://www.ic3.gov/Media/Y2020/PSA201002) election organizations.
 
-On top of that, using .gov **increases security**:
+Additionally, using .gov **increases security**:
 * [Multi-factor authentication]({{ site.baseurl }}/2018/10/1/doing-the-2-step/) is enforced on all accounts in the .gov registrar, different than commercial registrars.
-* We ‘[preload]({{ site.baseurl }}/2020/6/21/an-intent-to-preload/)’ all new domains, which requires browsers to only use a secure HTTPS connection with your website.
-* You can [add a security contact]({{ site.baseurl }}/help/security-best-practices/) to your domain, making it easier for the public to tell you of a potential security issue.
+* We ‘[preload]({{ site.baseurl }}/2020/6/21/an-intent-to-preload/)’ all new domains, which requires browsers to only use a secure HTTPS connection with your website. This protects your visitors' privacy and ensures the content you publish is exactly what's received.
+* You can [add a security contact]({{ site.baseurl }}/help/security-best-practices/) to WHOIS for your domain, making it easier for the public to tell you of a potential security issue with your online services.
 
 _If you're from the government, we're here to help_. Check out our [registration page]({{ site.baseurl }}/registration/) to begin.
 
@@ -27,12 +27,15 @@ _If you're from the government, we're here to help_. Check out our [registration
 
 * [We’re an elections office. Who is our authorizing authority?](#were-an-elections-office-who-is-our-authorizing-authority)
 * [We’ve been using our name in a different TLD. Can we get the same name in .gov?](#weve-been-using-our-name-in-a-different-tld-can-we-get-the-same-name-in-gov)
-* [Is there any support available as we transition to .gov?](#is-there-any-support-available-as-we-transition-to-gov)
+* [Is there any support available to transition to .gov?](#is-there-any-support-available-to-transition-to-gov)
 * [What other resources are available to elections offices?](#what-other-resources-are-available-to-elections-offices)
 
+(_General FAQs are available on our [help page]({{ site.baseurl }}/help/#frequently-asked-questions)_.)
 - - -
 
 #### We’re an elections office. Who is our authorizing authority?
+
+_See also "[What's an authorizing authority and who is ours?]({{ site.baseurl }}/help/#whats-an-authorizing-authority-and-who-is-ours)"_
 
 In general, elections offices maintain legal or practical autonomy from a municipality. Elections offices should follow the requirements for [independent intrastate]({{ site.baseurl }}/registration/requirements/#independent-intrastate-domains) domains. The authorization authority is the highest election official. For state-level election offices, the authorizing authority is typically the state's chief election official. For local-level election offices, the highest level election official is typically the elected or appointed official that runs the office.
 
@@ -40,18 +43,18 @@ In general, elections offices maintain legal or practical autonomy from a munici
 
 Your geographic area must be clear in the domain name. In many cases, this will require a [two-letter state abbreviation](https://pe.usps.com/text/pub28/28apb.htm) be added to the domain name. However, we allow exception requests; see [naming requirements]({{ site.baseurl }}/registration/requirements/#naming-requirements) on our [domain requirements]({{ site.baseurl }}/registration/requirements) page.
 
-#### Is there any support available as we transition to .gov?
+#### Is there any support available to transition to .gov?
 
-Though CISA has [removed]({{ site.baseurl }}/2021/4/27/a-new-day-for-gov/) registration and renewal fees, there are often costs associated with migrating to a new domain. These may include hiring technical staff or consultants to facilitate the switch. There may also be indirect costs, including replacing printed materials and informing the public of the change. While we cannot guarantee access to funds, election offices may wish to seek funding from the sources below:  
+Though CISA has [removed registration and renewal fees]({{ site.baseurl }}/2021/4/27/a-new-day-for-gov/), there are often costs associated with migrating to a new domain. These may include hiring technical staff or consultants to facilitate the switch, or  include indirect costs, like replacing printed materials and informing the public of the change. While we cannot guarantee access to funds, election offices may wish to seek funding from the following sources:  
 
 <h5>_Help America Vote Act Grants_</h5>
 The U.S. Election Assistance Commission (EAC) has acknowledged that Help America Vote Act (HAVA) funds can be used for the process of transitioning to a .gov domain. Election officials are advised to consult with the EAC before making any purchase to ensure it is an appropriate expenditure of funds under the rules governing the grants. For more information, [contact the EAC](https://www.eac.gov/contactuseac).
 
 <h5>_Homeland Security Grant Program_</h5>
-In the DOTGOV Act, “migrating any online service” to .gov became an allowable expense under the Homeland Security Grant Program. FEMA manages the grant program,  and potential grantees can include transitioning in their ‘investment justification’ submission. For more information, see [fema.gov](https://www.fema.gov/sites/default/files/documents/FEMA_2021-Preparedness-Grants-Manual_02-19-2021.pdf#page=50).
+The DOTGOV Act made “[migrating any online service](https://uscode.house.gov/view.xhtml?req=%22migrating+any+online+service%22&f=treesort&fq=true&num=0&hl=true&edition=prelim&granuleId=USC-prelim-title6-section609)” to .gov an allowable expense under the Homeland Security Grant Program. FEMA manages the grant program, and potential grantees may include transition costs in their ‘investment justification’ submission. For more information, see [FEMA's preparedness grants manual](https://www.fema.gov/sites/default/files/documents/FEMA_2021-Preparedness-Grants-Manual_02-19-2021.pdf#page=50) (PDF, page 50).
 
 <h5>_State and local collaboration_</h5>
-Election infrastructure often relies on municipality infrastructure, so you may consider collaborating locally to ensure resources are available to transition to .gov. (Non-election government organizations also qualify for a .gov domain!)
+Election infrastructure often relies on municipal infrastructure, so you may consider collaborating locally to secure resources to transition to .gov. (U.S.-based government organizations qualify for a .gov domain!)
 
 #### What other resources are available to elections offices?
 

--- a/pages/about/elections.md
+++ b/pages/about/elections.md
@@ -1,0 +1,58 @@
+---
+title: About .gov
+layout: docs
+permalink: /about/elections/
+intro: For the election community
+sidenav: about
+subnav:
+  - text: Why use .gov?
+    href: '#why-use-gov'
+  - text: What does .gov do?
+    href: '#what-does-gov-do'
+
+---
+State and local election offices are increasingly tasked with [countering false or misleading information](https://www.cisa.gov/mdm) _about_ an election on top of _administering_ an election. One concrete response you can take is to make it **easy to identify official election information on the internet**, a task made simple by .gov.  
+
+Using a .gov domain for your online presence (like your website and email) helps the public quickly identify you as a trusted government source. That confidence is merited because only U.S.-based government organizations can register a .gov domain. This is different than other well-known ‘top-level domains’ like _.com_, _.org_, or _.us_) where anyone in the world can register for a small fee. Malicious actors know this, and they’ve [sought to impersonate](https://www.ic3.gov/Media/Y2020/PSA201002) election organizations. A .gov domain name is available **at no cost**.
+
+On top of that, using .gov **increases security**:
+* [Multi-factor authentication]({{ site.baseurl }}/2018/10/1/doing-the-2-step/) is enforced on all accounts in the .gov registrar, different than commercial registrars.
+* We ‘[preload]({{ site.baseurl }}/2020/6/21/an-intent-to-preload/)’ all new domains, which requires browsers to only use a secure HTTPS connection with your website.
+* You can [add a security contact]({{ site.baseurl }}/help/security-best-practices/) to your domain, making it easier for the public to tell you of a potential security issue.
+
+_If you're from the government, we're here to help_. Check out our [registration page]({{ site.baseurl }}/registration/) to begin.
+
+- - -
+### Frequently asked questions
+
+* [We’re an elections office. Who is our authorizing authority?](#were-an-elections-office-who-is-our-authorizing-authority)
+* [We’ve been using our name in a different TLD. Can we get the same name in .gov?](#weve-been-using-our-name-in-a-different-tld-can-we-get-the-same-name-in-gov)
+* [Is there any support available as we transition to .gov?](#is-there-any-support-available-as-we-transition-to-gov)
+* [What other resources are available to elections offices?](#what-other-resources-are-available-to-elections-offices)
+
+- - -
+
+#### We’re an elections office. Who is our authorizing authority?
+
+In general, elections offices maintain legal or practical autonomy from a municipality. Elections offices should follow the requirements for [independent intrastate]({{ site.baseurl }}/registration/requirements/#independent-intrastate-domains) domains. The authorization authority is the highest election official. For state-level election offices, the authorizing authority is typically the state's chief election official. For local-level election offices, the highest level election official is typically the elected or appointed official that runs the office.
+
+#### We’ve been using our name in a different TLD. Can we get the same name in .gov?
+
+Your geographic area must be clear in the domain name. In many cases, this will require a [two-letter state abbreviation](https://pe.usps.com/text/pub28/28apb.htm) be added to the domain name. However, we allow exception requests; see [naming requirements]({{ site.baseurl }}/registration/requirements/#naming-requirements) on our [domain requirements]({{ site.baseurl }}/registration/requirements) page.
+
+#### Is there any support available as we transition to .gov?
+
+Though CISA has [removed]({{ site.baseurl }}/2021/4/27/a-new-day-for-gov/) registration and renewal fees, there are often costs associated with migrating to a new domain. These may include hiring technical staff or consultants to facilitate the switch. There may also be indirect costs, including replacing printed materials and informing the public of the change. While we cannot guarantee access to funds, election offices may wish to seek funding from the sources below:  
+
+<h5>_Help America Vote Act Grants_</h5>
+The U.S. Election Assistance Commission (EAC) has acknowledged that Help America Vote Act (HAVA) funds can be used for the process of transitioning to a .gov domain. Election officials are advised to consult with the EAC before making any purchase to ensure it is an appropriate expenditure of funds under the rules governing the grants. For more information, [contact the EAC](https://www.eac.gov/contactuseac).
+
+<h5>_Homeland Security Grant Program_</h5>
+In the DOTGOV Act, “migrating any online service” to .gov became an allowable expense under the Homeland Security Grant Program. FEMA manages the grant program,  and potential grantees can include transitioning in their ‘investment justification’ submission.” For more information, see [fema.gov](https://www.fema.gov/sites/default/files/documents/FEMA_2021-Preparedness-Grants-Manual_02-19-2021.pdf#page=50).
+
+<h5>_State and local collaboration_</h5>
+Election infrastructure often relies on municipality infrastructure, so you may consider collaborating locally to ensure resources are available to transition to .gov. (Non-election government organizations also qualify for a .gov domain!)
+
+#### What other resources are available to elections offices?
+
+CISA is committed to working collaboratively with those on the front lines of elections — state and local governments, election officials, federal partners, and vendors – to manage risks to the Nation’s election infrastructure. CISA provides guidance, products, and voluntary services to state and local election offices to support the election infrastructure community. For more information, visit the [CISA election security page](https://www.cisa.gov/election-security) or reach out to your [regional office](https://www.cisa.gov/cisa-regions) representative.   

--- a/pages/forms/federal.md
+++ b/pages/forms/federal.md
@@ -50,7 +50,7 @@ Address\
 Phone number\
 Email address
 
-**Security contact** [[required for the executive branch](https://cyber.dhs.gov/bod/20-01/#enable-receipt-of-unsolicited-reports), [recommended for others]({{ site.baseurl }}/help/security-best-practices/#add-a-security-contact)]\
+**Security contact** [[required for the executive branch](https://cyber.dhs.gov/bod/20-01/#enable-receipt-of-unsolicited-reports)]\
 Email address
 
 I understand that if I wish to retire \[\_\_\_\_\_\_\_\_\_\_\_.gov\], I must submit a written request to <registrar@dotgov.gov>.

--- a/pages/help/help.md
+++ b/pages/help/help.md
@@ -87,15 +87,15 @@ The requirements specify the *general* requirements that all domain registrants 
 
 #### What's an "authorizing authority", and who is ours?
 
-The authorizing authority is the official we'll accept as signatory for your .gov domain request. To determine who yours is, evaluate what kind of government organization yours is and follow the link:
+The authorizing authority is the official we'll accept as signatory for your .gov domain request. To determine who yours is, _evaluate what kind of government organization you are_ and follow the link (which will take you to the relevant section of our [domain requirements]({{ site.baseurl }}/registration/requirements/)):
 
 1. [Federal]({{site.baseurl}}/registration/requirements/#federal-domains): Federal agencies from all three branches of the federal government
-2. [Native sovereign nation]({{site.baseurl}}/registration/requirements/#native-sovereign-nation-tribal-domains): Tribal governments recognized by the federal government or a state government
+2. [Native sovereign nation (tribal)]({{site.baseurl}}/registration/requirements/#native-sovereign-nation-tribal-domains): Tribal governments recognized by the federal government or a state government
 3. [State/U.S. territories]({{site.baseurl}}/registration/requirements/#state-and-us-territory-domains): 50 U.S. states, District of Columbia (D.C.), American Samoa, Guam, Northern Mariana Islands, Puerto Rico, and U.S. Virgin Islands
-4. [Interstate]({{site.baseurl}}/registration/requirements/#interstate-domains):
+4. [Interstate]({{site.baseurl}}/registration/requirements/#interstate-domains): An organization of two or more states. From our domain requirements:
 > _Interstate (multi-state) governmental organizations are most frequently formed via legislation from Congress or from a legal accord between, or passed by, the state governments of two or more states. Examples include multi-state commissions, organizations that manage interstate compacts, or port authorities that operate across jurisdictions._
 
-5. [Independent intrastate]({{site.baseurl}}/registration/requirements/#independent-intrastate-domains):
+5. [Independent intrastate]({{site.baseurl}}/registration/requirements/#independent-intrastate-domains): An autonomous organization of a single state. From our domain requirements:
 > _Independent intrastate (within a single state) governmental organizations are most frequently formed via state or local legislation, where authority is vested in them to operate fully or quasi-independently from the state. Examples include organizations authorized by law that operate a jurisdiction’s elections, manage regional transit, or do area-wide economic planning with governance independent from e.g., the executive branch."_
 
 6. [City/County]({{site.baseurl}}/registration/requirements/#city-and-county-domains): Cities, towns, villages, counties, parishes, borough, or equivalents

--- a/pages/home.md
+++ b/pages/home.md
@@ -6,7 +6,7 @@ top: false
 
 hero:
   heading: It should be easy to identify governments on the internet.
-  content: .gov is the top-level domain for US-based government organizations.
+  content: .gov is the top-level domain for U.S.-based government organizations.
   button:
     text: Get a .gov domain
     href: /registration/

--- a/pages/updates/doing-the-2step.md
+++ b/pages/updates/doing-the-2step.md
@@ -28,26 +28,6 @@ A password is all that protects your account right now, and passwords can be eas
 ## Why is this change happening?
 Though you might only change your .gov domain or account information infrequently, someone with your password could sign in at any time and make changes. This extra layer of security makes it harder for someone to log in as you, which protects the services you make available to the public via a .gov domain.
 
-## What does this change mean for me?
-You will need to add 2-step verification to your account at [https://domains.dotgov.gov](https://domains.dotgov.gov). The feature will be rolling out gradually following the schedule below. Please note:
-
-1. The *first date* is the initial time you can add 2-step verification to your account.
-2. Between the two dates, if you're not ready to add 2-step verification, you'll be able to select "Remind me later".
-3. The *second date* is the enforcement date. On this date and after, you **must** enable 2-step verification on your account to manage your domain.
-
-### Rollout schedule
-
-* _GSA-owned domains_: October 1 - 31
-* _Federal Agency_: February 4, 2019
-* _Native Sovereign Nation_: October 8 -  November 7
-* _County_: October 22 - November 21
-* _State/Local Govt_: November 5 - December 5
-* _City_: Done in phases, based on the *first letter of your username*:
-  * *A - D*: November 19 - December 19
-  * *E - J*: December 5 - January 9, 2019
-  * *K - P*: December 17 - January 23, 2019
-  * *Q - Z*: January 14, 2019 - February 13, 2019
-
 ## How do I set up 2-step verification?
 
 In order to set up 2-step verification, you will need to use an [authentication app](#what-is-an-authentication-app) to generate security codes. *DotGov will only provide customer support for Google Authenticator*, but any application that implements the time-based one-time password (TOTP) standard will also work.

--- a/pages/updates/intent-to-preload.md
+++ b/pages/updates/intent-to-preload.md
@@ -13,7 +13,7 @@ subnav:
 ---
 ###### June 21, 2020
 
-<img src="/assets/img/dotgov-152.png" alt=".gov" style="float:left;margin:0 15px 15px 0"/>When the public sees information on a .gov website, they need to trust that it is official and accurate. This trust is warranted, because registration of a .gov domain is limited to bona fide US-based government organizations. Governments should be easy to identify on the internet and users should be secure on .gov websites.
+<img src="/assets/img/dotgov-152.png" alt=".gov" style="float:left;margin:0 15px 15px 0"/>When the public sees information on a .gov website, they are likely to trust that it is official and accurate. This trust is warranted, since registration of a .gov domain is limited to bona fide US-based government organizations. Governments should be easy to identify on the internet and users should be secure on .gov websites.
 
 HTTPS is a key protection for websites and web users. It offers security and privacy when connecting to the web, and provides governments the assurance that what they publish is what is delivered to users. In the last few years, HTTPS has become the default connection type on the web. Browsers that were once telling users to "watch for a green lock!" are now removing the lock icons. Instead, the browser warns users when sites are **not** using HTTPS.
 
@@ -38,8 +38,8 @@ Note that we're announcing *an intent to preload the TLD*, but **not actually pr
 With concerted effort, we could preload .gov within a few years. In order to support that goal and ascertain a feasible target deadline, **we are taking the following steps**:
 
 1. We are collaborating with the Cybersecurity and Infrastructure Security Agency (CISA) to help ensure .gov domain owners are ready for their domains to be preloaded in the future.
-2. We are teaming up with government-affiliated civic organizations to hold **presentations and listening sessions** in the coming months to get the word out about preloading .gov
-3. We have created a new listserv for **feedback from government agencies**. In particular, we'd like to hear the challenges agencies expect to face, and the solutions they develop that we can all use to resolve them. It's our hope that this new communications channel will generate discussion between government organizations. If you are a *current .gov account holder* or plan to request a new .gov domain in the future, please email <a href="mailto:dotgovhttps@listserv.gsa.gov">dotgovhttps@listserv.gsa.gov</a> using your .gov email and request to join the DotGov HTTPS listserv.
+2. We are teaming up with government-affiliated civic organizations to hold **presentations and listening sessions** in the coming months to get the word out about preloading .gov.
+3. We have created a new listserv for **feedback from government agencies**. In particular, we'd like to hear the challenges agencies expect to face, and the solutions they develop that we can all use to resolve them. It's our hope that this new communications channel will generate discussion between government organizations. Email <a href="mailto:dotgovhttps@listserv.gsa.gov">dotgovhttps@listserv.gsa.gov</a> to request to join.
 4. **Beginning September 1, 2020, all new .gov domains will be automatically preloaded**. This ensures that we're focused on transitioning historical domains, not new ones, and defaults to strong security going forward.
 
 After input from the community, we'll announce a target preloading date at a future time**.** For now, we've all got some work to do.


### PR DESCRIPTION
This PR adds an election-specific "about" page to guide the election community through what .gov is, how to get one, and some FAQs. 

For increased clarity, a few updates are also made to pages the new election content links to (help, 2-step, preload). There's also a few small errors fixed (federal, home).