### PR TITLE
Remove billing contact mentions

### DIFF
--- a/pages/forms/city-county.md
+++ b/pages/forms/city-county.md
@@ -25,18 +25,9 @@ In order to obtain and maintain [\_\_\_\_\_\_\_\_\_\_\_.gov] [City/County] will 
 
 The following will be listed as contacts for [\_\_\_\_\_\_\_\_\_\_\_.gov], which [City/County] will keep up to date in the .gov registrar.
 
-[*Administrative, billing, and technical contacts are named individuals and must be unique; a security contact should generally be a team email address.*
-
-*As of April 26, 2021, .gov domains no longer have a fee associated with them. However, the .gov registrar has not yet been updated to remove the billing contact role. Until then, you may consider the billing contact to be a secondary administrative contact.*]
+[*Administrative and technical contacts are named individuals and must be unique; a security contact should generally be a team email address.*]
 
 **Administrative contact**\
-First Last\
-Title\
-Address\
-Phone number\
-Email address
-
-**Billing contact**\
 First Last\
 Title\
 Address\

--- a/pages/forms/federal.md
+++ b/pages/forms/federal.md
@@ -25,18 +25,9 @@ In order to obtain and maintain [\_\_\_\_\_\_\_\_\_\_\_.gov] [Agency Name] will 
 
 The following will be listed as contacts for [\_\_\_\_\_\_\_\_\_\_\_.gov], which [Agency Name] will keep up to date in the .gov registrar.
 
-[*Administrative, billing, and technical contacts are named individuals and must be unique; a security contact should generally be a team email address.*
-
-*As of April 26, 2021, .gov domains no longer have a fee associated with them. However, the .gov registrar has not yet been updated to remove the billing contact role. Until then, you may consider the billing contact to be a secondary administrative contact.*]
+[*Administrative and technical contacts are named individuals and must be unique; a security contact should generally be a team email address.*]
 
 **Administrative contact**\
-First Last\
-Title\
-Address\
-Phone number\
-Email address
-
-**Billing contact**\
 First Last\
 Title\
 Address\

--- a/pages/forms/independent-intrastate.md
+++ b/pages/forms/independent-intrastate.md
@@ -25,18 +25,9 @@ In order to obtain and maintain [\_\_\_\_\_\_\_\_\_\_\_.gov] [Organization] will
 
 The following will be listed as contacts for [\_\_\_\_\_\_\_\_\_\_\_.gov], which [Organization] will keep up to date in the .gov registrar.
 
-[*Administrative, billing, and technical contacts are named individuals and must be unique; a security contact should generally be a team email address.*
-
-*As of April 26, 2021, .gov domains no longer have a fee associated with them. However, the .gov registrar has not yet been updated to remove the billing contact role. Until then, you may consider the billing contact to be a secondary administrative contact.*]
+[*Administrative and technical contacts are named individuals and must be unique; a security contact should generally be a team email address.*]
 
 **Administrative contact**\
-First Last\
-Title\
-Address\
-Phone number\
-Email address
-
-**Billing contact**\
 First Last\
 Title\
 Address\

--- a/pages/forms/interstate.md
+++ b/pages/forms/interstate.md
@@ -25,18 +25,9 @@ In order to obtain and maintain [\_\_\_\_\_\_\_\_\_\_\_.gov] [Organization] will
 
 The following will be listed as contacts for [\_\_\_\_\_\_\_\_\_\_\_.gov], which [Organization] will keep up to date in the .gov registrar.
 
-[*Administrative, billing, and technical contacts are named individuals and must be unique; a security contact should generally be a team email address.*
-
-*As of April 26, 2021, .gov domains no longer have a fee associated with them. However, the .gov registrar has not yet been updated to remove the billing contact role. Until then, you may consider the billing contact to be a secondary administrative contact.*]
+[*Administrative and technical contacts are named individuals and must be unique; a security contact should generally be a team email address.*]
 
 **Administrative contact**\
-First Last\
-Title\
-Address\
-Phone number\
-Email address
-
-**Billing contact**\
 First Last\
 Title\
 Address\

--- a/pages/forms/native-sovereign-nation.md
+++ b/pages/forms/native-sovereign-nation.md
@@ -25,18 +25,9 @@ In order to obtain and maintain [\_\_\_\_\_\_\_\_\_\_\_.gov] [Tribe] will meet t
 
 The following will be listed as contacts for [\_\_\_\_\_\_\_\_\_\_\_.gov], which [Tribe] will keep up to date in the .gov registrar.
 
-[*Administrative, billing, and technical contacts are named individuals and must be unique; a security contact should generally be a team email address.*
-
-*As of April 26, 2021, .gov domains no longer have a fee associated with them. However, the .gov registrar has not yet been updated to remove the billing contact role. Until then, you may consider the billing contact to be a secondary administrative contact.*]
+[*Administrative and technical contacts are named individuals and must be unique; a security contact should generally be a team email address.*]
 
 **Administrative contact**\
-First Last\
-Title\
-Address\
-Phone number\
-Email address
-
-**Billing contact**\
 First Last\
 Title\
 Address\

--- a/pages/forms/state-territory.md
+++ b/pages/forms/state-territory.md
@@ -25,18 +25,9 @@ In order to obtain and maintain [\_\_\_\_\_\_\_\_\_\_\_.gov] [Organization] will
 
 The following will be listed as contacts for [\_\_\_\_\_\_\_\_\_\_\_.gov], which [Organization] will keep up to date in the .gov registrar.
 
-[*Administrative, billing, and technical contacts are named individuals and must be unique; a security contact should generally be a team email address.*
-
-*As of April 26, 2021, .gov domains no longer have a fee associated with them. However, the .gov registrar has not yet been updated to remove the billing contact role. Until then, you may consider the billing contact to be a secondary administrative contact.*]
+[*Administrative and technical contacts are named individuals and must be unique; a security contact should generally be a team email address.*]
 
 **Administrative contact**\
-First Last\
-Title\
-Address\
-Phone number\
-Email address
-
-**Billing contact**\
 First Last\
 Title\
 Address\

--- a/pages/forms/transfers.md
+++ b/pages/forms/transfers.md
@@ -32,13 +32,6 @@ Address\
 Phone number\
 Email address
 
-**Billing contact**\
-First Last\
-Title\
-Address\
-Phone number\
-Email address
-
 **Technical contact**\
 First Last\
 Title\

--- a/pages/help/help.md
+++ b/pages/help/help.md
@@ -119,13 +119,11 @@ Domain name registrants [must]({{site.baseurl}}/registration/requirements/#requi
 
 Administrative and technical contacts have accounts to the .gov registrar and can make changes to your DNS nameservers.
 
-(A legacy contact, the *billing contact*, remains, even though domains are now [available at no cost]({{site.baseurl}}/2021/4/27/a-new-day-for-gov/). You may consider it a secondary administrative contact.)
-
 A **[security contact]({{ site.baseurl }}/help/security-best-practices/#add-a-security-contact)** is a recommended practice. It should be added to allow the public to report observed or suspected security issues at your domain. *Security contact details are made public.* We recommend using an alias, like `security@<domain.gov>`.
 
 > **Note**: The security contact role *does not* have an account to the .gov registrar.
 
-At present, we don't allow a single person to serve as more than one contact – even for the billing account - meaning that three distinct contacts are required. (This does *not* apply to security contact.)
+At present, we don't allow a single person to serve as more than one contact - meaning that two distinct contacts are required. (This does *not* apply to security contact.)
 
 #### How do I request an exception to the naming requirements?
 
@@ -191,7 +189,7 @@ A current contact should [contact us](#contact-us) to establish a new user accou
 
 #### Can one person serve as contacts on a single domain?
 
-No. At present, we don't allow a single person to serve as more than one contact – even for the billing account - meaning that three distinct contacts are required. (This does *not* apply to security contact.)
+No. At present, we don't allow a single person to serve as more than one contact – meaning that two distinct contacts are required. (This does *not* apply to security contact.)
 
 #### Can a person serve as a contact on multiple domains?
 


### PR DESCRIPTION
As of today, new domain registrations no longer require a billing contact (legacy registrations are unaffected). This PR removes billing contact language from the authorization template letters and the help page.