### PR TITLE
Removed redundant "account"

### DIFF
--- a/pages/updates/2023-transition-email.md
+++ b/pages/updates/2023-transition-email.md
@@ -26,7 +26,7 @@ Login.gov provides a simple and secure process for signing into many government 
 
 1.  First, check which email address you use in the current registrar. Log in at [https://domains.dotgov.gov](https://domains.dotgov.gov) and click "Account" in the side navigation. If you need to update this address, please [contact us]({{ site.baseurl }}/help/#contact-us).
 
-2.  Next, [create a Login.gov account](https://www.login.gov/create-an-account/) account. Verify your identity to confirm you're you and not someone pretending to be you. Once you have your Login.gov account, you're all set. We'll email you when you can access the new registrar. (If you need assistance setting up your account, review [https://login.gov/help/](https://login.gov/help/).)
+2.  Next, [create a Login.gov account](https://www.login.gov/create-an-account/). Verify your identity to confirm you're you and not someone pretending to be you. Once you have your Login.gov account, you're all set. We'll email you when you can access the new registrar. (If you need assistance setting up your account, review [https://login.gov/help/](https://login.gov/help/).)
 
 *If you don't take these actions **before early November**, you will lose the ability to make changes to your domain's nameservers.* However, your DNS will remain unchanged and will still resolve online.
 


### PR DESCRIPTION
Removed redundant "account" from  `Next, [create a Login.gov account](https://www.login.gov/create-an-account/) account`