### PR TITLE
Implement a mobile only banner to complement the desktop only one

### DIFF
--- a/_includes/components/banner.html
+++ b/_includes/components/banner.html
@@ -40,3 +40,6 @@
       </div>
     </div>
   </div>
+  <div class="header-alert header-alert--mobile">
+    <p><i class="fa fa-info-circle" aria-hidden="true"></i> Requests for new .gov domains are paused until January 2024. See <a href="{{ site.baseurl }}/updates/2023/10/13/transition-update/">our blog post</a> to learn more.</p>
+  </div>

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -468,6 +468,14 @@ h2, h3, h4, h5, h6 {
   }
 }
 
+.header-alert--mobile {
+  display: block;
+  position: relative;
+  @include media($nav-width) {
+    display: none;
+  }
+}
+
 .page-federal-policy {
   hr {
     @include margin(3rem null);


### PR DESCRIPTION
Note: there's duplicate markup for the mobile banner. This should not be an issue semantically or for accessibility (in any case, `display: none` is ignored by SRs).

Local dev env is messed up but I have a pretty good indication that this might work:

![Screen Shot 2023-10-13 at 5 41 47 PM](https://github.com/cisagov/dotgov-home/assets/107004823/06d15311-24fb-4670-b6cd-bbaa9edd2a97)
![Screen Shot 2023-10-13 at 5 41 40 PM](https://github.com/cisagov/dotgov-home/assets/107004823/12bd7b63-7f9c-4bbc-82ea-fc2231f88bf6)
