### PR TITLE
Make home into a status page and every page redirect there

### DIFF
--- a/_layouts/blank.html
+++ b/_layouts/blank.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="{{ page.lang | default: site.lang | default: 'en-US' }}">
+  <head>
+    {% include meta.html %}
+    {% include styles.html %}
+  </head>
+  <body class="page-{{ page.title | slugify }} {{ layout.class }} {{ page.class }}">
+
+    <div class="usa-grid usa-content">
+    <main id="main-content"{% for _attr in layout.main %} {{ _attr[0] }}="{{ _attr[1] }}"{% endfor %}>
+      <div class="usa-prose">
+        {{ content }}
+      </div>
+    </main>
+    </div>
+
+    {% include scripts.html %}
+  </body>
+</html>

--- a/pages/about/about.md
+++ b/pages/about/about.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: /
 title: About
 layout: docs
 permalink: /about/

--- a/pages/about/elections.md
+++ b/pages/about/elections.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: /
 title: About .gov, for elections
 layout: docs
 permalink: /about/elections/

--- a/pages/data.md
+++ b/pages/data.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: /
 title: Data
 layout: docs
 permalink: /data/

--- a/pages/forms/city-county.md
+++ b/pages/forms/city-county.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: /
 title: "Authorization letter template: City/County"
 layout: docs
 permalink: /registration/authorization-templates/city-county/

--- a/pages/forms/federal.md
+++ b/pages/forms/federal.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: /
 title: "Authorization letter template: Federal"
 layout: docs
 permalink: /registration/authorization-templates/federal/

--- a/pages/forms/independent-intrastate.md
+++ b/pages/forms/independent-intrastate.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: /
 title: "Authorization letter template: Independent intrastate"
 layout: docs
 permalink: /registration/authorization-templates/independent-intrastate/

--- a/pages/forms/interstate.md
+++ b/pages/forms/interstate.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: /
 title: "Authorization letter template: Interstate"
 layout: docs
 permalink: /registration/authorization-templates/interstate/

--- a/pages/forms/native-sovereign-nation.md
+++ b/pages/forms/native-sovereign-nation.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: /
 title: "Authorization letter template: Tribal"
 layout: docs
 permalink: /registration/authorization-templates/tribal/

--- a/pages/forms/state-territory.md
+++ b/pages/forms/state-territory.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: /
 title: "Authorization letter template: State/U.S. Territory"
 layout: docs
 permalink: /registration/authorization-templates/state-territory/

--- a/pages/forms/transfers.md
+++ b/pages/forms/transfers.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: /
 title: "Domain Transfer Letter"
 layout: docs
 permalink: /management/authorization-templates/transfers/

--- a/pages/help/help.md
+++ b/pages/help/help.md
@@ -1,4 +1,6 @@
 ---
+redirect_to: /
+redirect_to: /
 title: Help Center
 layout: docs
 permalink: /help/

--- a/pages/help/help.md
+++ b/pages/help/help.md
@@ -1,6 +1,5 @@
 ---
 redirect_to: /
-redirect_to: /
 title: Help Center
 layout: docs
 permalink: /help/

--- a/pages/help/security-best-practices.md
+++ b/pages/help/security-best-practices.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: /
 title: Domain security best practices
 layout: docs
 permalink: /help/security-best-practices/

--- a/pages/help/what-to-think-about.md
+++ b/pages/help/what-to-think-about.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: /
 title: What to Think About When You're <i>Thinking About</i> Moving to .gov
 layout: docs
 permalink: /help/what-to-think-about-moving-to-gov/

--- a/pages/home.md
+++ b/pages/home.md
@@ -24,7 +24,9 @@ changes coming to .gov.
 
 <h2>Domain management</h2>
 
-<p>You’ll be able to manage your existing .gov domains in our new registrar on November 17, 2024.</p>
+<p>On November 15th, 2023, we emailed all domain contacts with instructions to
+log into the new .gov registrar. If you're a contact and didn't receive an
+email, send us a message at <a href="mailto:help@get.gov">help@get.gov</a>.</p>
 
 <h2>New .gov domain requests</h2>
 

--- a/pages/home.md
+++ b/pages/home.md
@@ -25,7 +25,7 @@ changes coming to .gov.
 <h2>Domain management</h2>
 
 <p>On November 15th, 2023, we emailed all domain contacts with instructions to
-log into the new .gov registrar. If you're a contact and didn't receive an
+log into the new .gov registrar. If you're a domain contact and didn't receive this
 email, send us a message at <a href="mailto:help@get.gov">help@get.gov</a>.</p>
 
 <h2>New .gov domain requests</h2>

--- a/pages/home.md
+++ b/pages/home.md
@@ -1,6 +1,6 @@
 ---
 title: Home
-layout: landing
+layout: blank
 permalink: /
 top: false
 
@@ -12,18 +12,26 @@ hero:
     href: https://domains.dotgov.gov
 ---
 
-<section class="usa-section">
-  <div class="usa-grid usa-content">
-<div class="usa-width-one-third">
-## Recent updates
-</div>
+<h1>The .gov registrar is moving</h1>
 
-<div class="usa-width-two-thirds">
+<p>We are moving the .gov registrar to new technical infrastructure. At this
+time, you can’t request a new .gov domain or manage your existing .gov
+domains, but DNS for existing domains will not change and will still resolve
+online. Email <a href="mailto:help@get.gov">help@get.gov</a> with questions.
+Visit our <a href="https://beta.get.gov">beta.get.gov</a> site to preview the
+changes coming to .gov.
+</p>
 
-**October 13th, 2023**: New domain requests are [paused]({{ site.baseurl }}/updates/2023/10/13/transition-update/) until January 2024 as we transition to new infrastructure.
+<h2>Domain management</h2>
 
-**September 6, 2023**: We're leading a [change to .gov's infrastructure]({{ site.baseurl }}/updates/2023/9/6/infrastructure-as-a-public-service/) that requires current users to take certain actions. In October 2023, we'll also initiate a pause on new domain requests.
+<p>You’ll be able to manage your existing .gov domains in our new registrar on November 17, 2024.</p>
 
-**February 8th, 2023**: Federal executive branch agencies have [updated requirements]({{ site.baseurl }}/registration/requirements/#executive-branch) for the registration and use of .gov domains, via [OMB Memorandum 23-10](https://www.whitehouse.gov/wp-content/uploads/2023/02/M-23-10-DOTGOV-Act-Guidance.pdf). The update details how domains are requested and which may be approved.
+<h2>New .gov domain requests</h2>
 
-**January 31st, 2023**: The .gov zone file is [now available](https://czds.icann.org/home) in ICANN's Centralized Zone Data Service. [Learn more]({{ site.baseurl }}/updates/2022/9/14/making-infrastructure-less-invisible/#publishing-the-gov-zone-file) in last September's blog post.
+<p>You’ll be able to request a new .gov domain in January 2024. Find out <a
+href="https://beta.get.gov/domains/before/">what you’ll need to request a
+.gov</a> in our new registrar.</p>
+
+
+<p><br/>Thank you for your patience as we launch a new .gov registrar!</p>
+

--- a/pages/privacy.md
+++ b/pages/privacy.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: /
 title: Privacy policy
 layout: docs
 permalink: /privacy/

--- a/pages/registration/registration.md
+++ b/pages/registration/registration.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: /
 title: Registration
 layout: docs
 permalink: /registration/

--- a/pages/registration/request-templates.md
+++ b/pages/registration/request-templates.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: /
 title: Authorization letter templates
 layout: docs
 permalink: /registration/authorization-templates/

--- a/pages/registration/requirements-retired.md
+++ b/pages/registration/requirements-retired.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: /
 title: Domain requirements (retired)
 layout: docs
 permalink: /registration/requirements-retired/

--- a/pages/registration/requirements.md
+++ b/pages/registration/requirements.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: /
 title: Domain requirements
 layout: docs
 permalink: /registration/requirements/

--- a/pages/updates/2022-omnibus.md
+++ b/pages/updates/2022-omnibus.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: /
 title: Making infrastructure less invisible
 layout: docs
 permalink: /updates/2022/9/14/making-infrastructure-less-invisible/

--- a/pages/updates/2023-transition-email.md
+++ b/pages/updates/2023-transition-email.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: /
 title: Action required for your .gov account
 layout: docs    
 permalink: /updates/2023/9/6/transition-email/

--- a/pages/updates/2023-transition.md
+++ b/pages/updates/2023-transition.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: /
 title: Infrastructure as a (public) service
 layout: docs
 permalink: /updates/2023/9/6/infrastructure-as-a-public-service/

--- a/pages/updates/doing-the-2step.md
+++ b/pages/updates/doing-the-2step.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: /
 title: 2-step Verification
 layout: docs
 permalink: /2018/10/1/doing-the-2-step/

--- a/pages/updates/increase-security-passwords.md
+++ b/pages/updates/increase-security-passwords.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: /
 title: Increasing the security of passwords
 layout: docs
 permalink: /2018/4/17/increase-security-passwords/

--- a/pages/updates/intent-to-preload.md
+++ b/pages/updates/intent-to-preload.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: /
 title: An intent to preload
 layout: docs
 permalink: /2020/6/21/an-intent-to-preload/

--- a/pages/updates/moving-to-cisa.md
+++ b/pages/updates/moving-to-cisa.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: /
 title: .gov is moving to CISA
 layout: docs
 permalink: /2021/3/8/moving-to-cisa/

--- a/pages/updates/new-day-for-gov.md
+++ b/pages/updates/new-day-for-gov.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: /
 title: A new day for .gov
 layout: docs
 permalink: /2021/4/27/a-new-day-for-gov/

--- a/pages/updates/october-2023-update.md
+++ b/pages/updates/october-2023-update.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: /
 title: An update on our transition
 layout: docs
 permalink: /updates/2023/10/13/transition-update/

--- a/pages/updates/preloading.md
+++ b/pages/updates/preloading.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: /
 title: HSTS preloading
 layout: docs
 permalink: /management/preloading/

--- a/pages/updates/updates.md
+++ b/pages/updates/updates.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: /
 title: Updates
 layout: docs
 intro: What's happening around .gov


### PR DESCRIPTION
This replaces the content of `home.md` with our pause status page and adds `redirect_to: /` to every other page which makes Jekyll put a meta-refresh redirect on every one of those pages. This will make all inlinks to existing pages lead people back to our status page.

![Screenshot 2023-11-03 at 2 40 39 PM](https://github.com/cisagov/dotgov-home/assets/443389/b388e302-5630-4190-a604-535113bd3f4f)

When this is merged to `main` it will take all content off of get.gov, so we should only do that exactly when we mean to.

