### PR TITLE
Post launch updates

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -11,8 +11,7 @@
       <div class="usa-width-one-third">
         <h3>Contact us</h3>
         <p>
-          Phone: <a href="tel:1-877-734-4688">1-877-734-4688</a><br/>
-          Email: <a href="mailto:registrar@dotgov.gov">registrar@dotgov.gov</a>
+          Email: <a href="mailto:help@get.gov">help@get.gov</a>
         </p>
         <a class="footer-logo" href="{{ site.baseurl }}/">
           {% include svg/dottedgov-round.svg %}
@@ -21,9 +20,8 @@
       <div class="usa-width-one-third">
         <h3>Tools and services</h3>
         <ul class="usa-unstyled-list">
-          <li><a href="https://domains.dotgov.gov" target="_blank" rel="noopener">Manage your domain</a></li>
+          <li><a href="https://manage.get.gov" target="_blank" rel="noopener">Manage your domain</a></li>
           <li><a href="{{ site.baseurl }}/data">Use our data</a></li>
-          <li><a href="https://domains.dotgov.gov/dotgov-web/registration/whois.xhtml?_m=3">WHOIS search</a></li>
           <li><a href="{{ site.baseurl }}/help/security-best-practices/">Domain security best practices</a></li>
         </ul>
       </div>

--- a/pages/help/help.md
+++ b/pages/help/help.md
@@ -23,10 +23,8 @@ subnav:
     href: '#renewals-transfers-and-deletions'
 ---
 ### Contact us
-Support is available 7 a.m. to 7 p.m. Eastern Time [(except public holidays)](https://www.opm.gov/policy-data-oversight/pay-leave/federal-holidays/), and 24/7 for emergencies.
 
-* **Email**: <registrar@dotgov.gov>
-* **Phone**: <a href="tel:1-877-734-4688">1-877-734-4688</a>
+Email us at help@get.gov.
 
 ---
 

--- a/pages/home.md
+++ b/pages/home.md
@@ -9,7 +9,7 @@ hero:
   content: .gov is the top-level domain for U.S.-based government organizations.
   button:
     text: Manage your domain
-    href: https://domains.dotgov.gov
+    href: https://manage.get.gov
 ---
 
 <section class="usa-section">


### PR DESCRIPTION
These updates will be published after the registrar launch. The [status page will be reverted](https://github.com/cisagov/dotgov-home/pull/163) before this PR is merged.

- Updated support email address
- Removed support phone number
- Removed WHOIS link in footer
- Added registrar link on home page and in footer